### PR TITLE
Prevent refcursors being prematurely closed

### DIFF
--- a/qresult.c
+++ b/qresult.c
@@ -99,14 +99,22 @@ QR_set_cursor(QResultClass *self, const char *name)
 	}
 	else
 	{
-		QResultClass *res;
-
 		self->cursor_name = NULL;
-		for (res = QR_nextr(self); NULL != res; res = QR_nextr(res))
+		
+		/*
+		* Free other cursors for SQL Server only, so refcursors do not get freed
+		* prematurely. See commit c07342d22d82ea6293d27057840babfc2ff6d750.
+		*/
+		if (isSqlServr())
 		{
-			if (NULL != res->cursor_name)
-				free(res->cursor_name);
-			res->cursor_name = NULL;
+			QResultClass *res;
+
+			for (res = QR_nextr(self); NULL != res; res = QR_nextr(res))
+			{
+				if (NULL != res->cursor_name)
+					free(res->cursor_name);
+				res->cursor_name = NULL;
+			}
 		}
 	}
 }

--- a/test/expected/fetch-refcursors.out
+++ b/test/expected/fetch-refcursors.out
@@ -2,25 +2,25 @@ Creating procedure 'refproc'
 connected
 disconnecting
 
--- TEST using FetchRefcursors=0, autocommit=1, numresults=2
+-- TEST using Fetch=1;FetchRefcursors=0, autocommit=1, numresults=2
 connected
 Output param num_cursor is 2
 --1 Result set:
 2	<unnamed portal 1>	<unnamed portal 2>
 disconnecting
 
--- TEST using FetchRefcursors=1, autocommit=1, numresults=2
+-- TEST using Fetch=1;FetchRefcursors=1, autocommit=1, numresults=2
 connected
 SQLExecute failed
 HY000=Query must be executed in a transaction when FetchRefcursors setting is enabled.
 
--- TEST using FetchRefcursors=1, autocommit=0, numresults=0
+-- TEST using Fetch=1;FetchRefcursors=1, autocommit=0, numresults=0
 connected
 Output param num_cursor is 0
 --1 Result set:
 disconnecting
 
--- TEST using FetchRefcursors=1, autocommit=0, numresults=1
+-- TEST using Fetch=1;FetchRefcursors=1, autocommit=0, numresults=1
 connected
 Output param num_cursor is 1
 --1 Result set:
@@ -29,7 +29,7 @@ Output param num_cursor is 1
 3	foobar
 disconnecting
 
--- TEST using FetchRefcursors=1, autocommit=0, numresults=2
+-- TEST using Fetch=1;FetchRefcursors=1, autocommit=0, numresults=2
 connected
 Output param num_cursor is 2
 --1 Result set:
@@ -42,7 +42,7 @@ bar	2
 foo	1
 disconnecting
 
--- TEST using FetchRefcursors=1, autocommit=0, numresults=3
+-- TEST using Fetch=1;FetchRefcursors=1, autocommit=0, numresults=3
 connected
 Output param num_cursor is 2
 --1 Result set:

--- a/test/src/fetch-refcursors-test.c
+++ b/test/src/fetch-refcursors-test.c
@@ -108,12 +108,12 @@ int main(int argc, char **argv)
 {
 	setup_procedure();
 
-	refcursor_test("FetchRefcursors=0", SQL_AUTOCOMMIT_ON, 2);
-	refcursor_test("FetchRefcursors=1", SQL_AUTOCOMMIT_ON, 2);
-	refcursor_test("FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 0);
-	refcursor_test("FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 1);
-	refcursor_test("FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 2);
-	refcursor_test("FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 3);
+	refcursor_test("Fetch=1;FetchRefcursors=0", SQL_AUTOCOMMIT_ON, 2);
+	refcursor_test("Fetch=1;FetchRefcursors=1", SQL_AUTOCOMMIT_ON, 2);
+	refcursor_test("Fetch=1;FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 0);
+	refcursor_test("Fetch=1;FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 1);
+	refcursor_test("Fetch=1;FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 2);
+	refcursor_test("Fetch=1;FetchRefcursors=1", SQL_AUTOCOMMIT_OFF, 3);
 
 	return 0;
 }


### PR DESCRIPTION
Not sure why this function frees all remaining cursors. There are no tests that need this code to pass so its purpose is not clear. It can cause refcursors to be closed prematurely when multiple fetches per refcursor are required.

The code was added in commit [c07342d22d82ea6293d27057840babfc2ff6d750](https://github.com/iress/psqlodbc/commit/c07342d22d82ea6293d27057840babfc2ff6d750) to fix a crash when using SQL Server linked servers. I'm going to assume that this code is only required for SQL Server, despite the change that prevents a crash being in a different file (`parse.c`). Because the change is in the same commit, I'm making this code run only for SQL Server. A bit of a hacky fix but it's the best we can do in the absence of relevant tests.

Also updated the refcursor test to ensure the bug doesn't resurface.